### PR TITLE
Add serverless WhatsApp assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,37 @@
-# WhatsApp AI Assistant – Support & Sales  
+# WhatsApp AI Assistant – Support & Sales
 Serverless on AWS ‧ Bedrock ‧ Twilio WhatsApp ‧ React Admin UI
 
 ---
 
 ## ✨ Overview
-This repository deploys an end-to-end solution that:
+This repository deploys an end-to-end solution that integrates WhatsApp with Amazon Bedrock to classify intents and fill dynamic slots. Conversations are stored in DynamoDB and can be browsed through a minimal React admin portal served from S3/CloudFront.
 
-| Layer | Tech | Purpose |
-|-------|------|---------|
-| **Messaging** | Twilio WhatsApp → API Gateway | Receives customer messages via webhook |
-| **LLM Orchestration** | AWS Lambda + LangChain + **Amazon Bedrock** | Classifies intent (Soporte / Ventas) and does slot-filling |
-| **State** | DynamoDB (`ConversationState`) | Persists conversation context + message log |
-| **Integrations** | SOHO CRM (REST) • Lead mock | Creates casos de servicio o leads |
-| **Admin API** | API Gateway (x-api-key) | Lists & fetches conversations for the UI |
-| **Admin UI** | React 18 + Vite → S3 + CloudFront | Allows internal users to browse chats |
-| **IaC** | AWS CDK (v2, TypeScript) | Defines all cloud resources |
-| **CI / Tests** | Jest + npm scripts | Basic unit tests for Lambdas |
+## 📦 Packages
+- **cdk** – CDK app and Lambda source code.
+- **admin-frontend** – React admin interface.
 
-Architecture diagram (simplified):
+## 🚀 Deployment
+Install dependencies and run the CDK deploy command:
 
+```bash
+npm install
+npm --workspace=cdk run build
+cdk deploy
+```
+
+Set the environment variables `SOHO_CRM_API_URL`, `SOHO_CRM_API_KEY`, `ADMIN_API_KEY` and optionally `SLOT_CONFIG_JSON` before deployment.
+
+The admin UI can be built with:
+
+```bash
+npm --workspace=admin-frontend run build
+```
+
+The generated files in `admin-frontend/dist` should be uploaded to the S3 bucket indicated in the stack output.
+
+## 🧪 Tests
+Run unit tests with:
+
+```bash
+npm test
+```

--- a/admin-frontend/package.json
+++ b/admin-frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "admin-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18",
+    "react-dom": "^18",
+    "zustand": "^4"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "vite": "^4",
+    "@vitejs/plugin-react": "^4"
+  }
+}

--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -1,0 +1,16 @@
+import ConversationList from './components/ConversationList';
+import ConversationView from './components/ConversationView';
+import { useState } from 'react';
+import './app.css';
+
+function App() {
+  const [selected, setSelected] = useState<string | null>(null);
+  return (
+    <div className="flex h-screen">
+      <ConversationList onSelect={setSelected} />
+      {selected && <ConversationView sessionId={selected} />}
+    </div>
+  );
+}
+
+export default App;

--- a/admin-frontend/src/api.ts
+++ b/admin-frontend/src/api.ts
@@ -1,0 +1,15 @@
+const API_KEY = import.meta.env.VITE_ADMIN_API_KEY;
+
+export async function listConversations() {
+  const res = await fetch('/admin/conversations', {
+    headers: { 'x-api-key': API_KEY }
+  });
+  return res.json();
+}
+
+export async function getConversation(id: string) {
+  const res = await fetch(`/admin/conversations/${id}`, {
+    headers: { 'x-api-key': API_KEY }
+  });
+  return res.json();
+}

--- a/admin-frontend/src/components/ConversationList.tsx
+++ b/admin-frontend/src/components/ConversationList.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { listConversations } from '../api';
+
+export default function ConversationList({ onSelect }: { onSelect: (id: string) => void }) {
+  const [items, setItems] = useState<any[]>([]);
+  useEffect(() => {
+    listConversations().then(setItems);
+  }, []);
+  return (
+    <aside className="w-64 border-r overflow-y-auto">
+      <ul>
+        {items.map(item => (
+          <li key={item.sessionId} className="p-2 border-b cursor-pointer" onClick={() => onSelect(item.sessionId)}>
+            {item.sessionId}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/admin-frontend/src/components/ConversationView.tsx
+++ b/admin-frontend/src/components/ConversationView.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { getConversation } from '../api';
+
+export default function ConversationView({ sessionId }: { sessionId: string }) {
+  const [conv, setConv] = useState<any>(null);
+  useEffect(() => {
+    getConversation(sessionId).then(setConv);
+  }, [sessionId]);
+
+  if (!conv) return <div className="flex-1">Loading...</div>;
+  return (
+    <div className="flex-1 p-4 overflow-y-auto">
+      <pre>{JSON.stringify(conv, null, 2)}</pre>
+    </div>
+  );
+}

--- a/admin-frontend/src/main.tsx
+++ b/admin-frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/admin-frontend/tsconfig.json
+++ b/admin-frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "es2022"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*"]
+}

--- a/admin-frontend/vite.config.ts
+++ b/admin-frontend/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './'
+});

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { WhatsAppAiStack } from '../lib/WhatsAppAiStack';
+
+const app = new cdk.App();
+new WhatsAppAiStack(app, 'WhatsAppAiStack');

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/cdk.ts"
+}

--- a/cdk/config/slotConfig.ts
+++ b/cdk/config/slotConfig.ts
@@ -1,0 +1,31 @@
+export const defaultSlotConfig = {
+  soporte: {
+    required: [
+      "cliente",
+      "marca_central",
+      "contacto",
+      "contacto_tel",
+      "contacto_email",
+      "ubicacion",
+      "detalle_problema",
+      "check_conexiones",
+      "check_internet",
+      "check_lineas",
+      "reporto_operador"
+    ]
+  },
+  ventas: {
+    required: [
+      "cliente",
+      "articulo",
+      "contacto",
+      "contacto_tel",
+      "contacto_email",
+      "ubicacion",
+      "central_extensiones",
+      "operador_lineas"
+    ]
+  }
+} as const;
+
+export type SlotConfig = typeof defaultSlotConfig;

--- a/cdk/jest.config.js
+++ b/cdk/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ["/dist/"]
+};

--- a/cdk/lib/WhatsAppAiStack.ts
+++ b/cdk/lib/WhatsAppAiStack.ts
@@ -1,0 +1,110 @@
+import { Duration, Stack, StackProps, RemovalPolicy, CfnOutput } from "aws-cdk-lib";
+import { Construct } from 'constructs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+
+export class WhatsAppAiStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const table = new dynamodb.Table(this, 'ConversationState', {
+      partitionKey: { name: 'sessionId', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'timestamp', type: dynamodb.AttributeType.STRING },
+      removalPolicy: RemovalPolicy.DESTROY
+    });
+
+    const commonEnv = {
+      SOHO_CRM_API_URL: process.env.SOHO_CRM_API_URL || '',
+      SOHO_CRM_API_KEY: process.env.SOHO_CRM_API_KEY || '',
+      ADMIN_API_KEY: process.env.ADMIN_API_KEY || '',
+      SLOT_CONFIG_JSON: process.env.SLOT_CONFIG_JSON || ''
+    };
+
+    const handler = new lambda.Function(this, 'WhatsAppHandler', {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      handler: 'handler.main',
+      code: lambda.Code.fromAsset('dist'),
+      environment: commonEnv,
+      timeout: Duration.seconds(30)
+    });
+
+    const getConversations = new lambda.Function(this, 'GetConversations', {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      handler: 'getConversations.main',
+      code: lambda.Code.fromAsset('dist'),
+      environment: commonEnv,
+      timeout: Duration.seconds(15)
+    });
+
+    const getConversationDetail = new lambda.Function(this, 'GetConversationDetail', {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      handler: 'getConversationDetail.main',
+      code: lambda.Code.fromAsset('dist'),
+      environment: commonEnv,
+      timeout: Duration.seconds(15)
+    });
+
+    table.grantReadWriteData(handler);
+    table.grantReadData(getConversations);
+    table.grantReadData(getConversationDetail);
+
+    const bedrockPolicy = new iam.PolicyStatement({
+      actions: ['bedrock:InvokeModel'],
+      resources: ['*']
+    });
+    handler.addToRolePolicy(bedrockPolicy);
+
+    const api = new apigw.RestApi(this, 'Api', {});
+    const webhook = api.root.addResource('webhook');
+    webhook.addMethod('POST', new apigw.LambdaIntegration(handler));
+
+    const admin = api.root.addResource('admin');
+    const conv = admin.addResource('conversations');
+    const convId = conv.addResource('{sessionId}');
+
+
+    const apiKey = api.addApiKey('AdminApiKey');
+    const usagePlan = api.addUsagePlan('UsagePlan', { throttle: { rateLimit: 5, burstLimit: 10 } });
+    usagePlan.addApiKey(apiKey);
+    usagePlan.addApiStage({ stage: api.deploymentStage });
+
+    const authorizer = new apigw.RequestAuthorizer(this, 'ApiKeyAuthorizer', {
+      handler: new lambda.Function(this, 'ApiKeyAuthorizerFn', {
+        runtime: lambda.Runtime.NODEJS_18_X,
+        handler: 'index.handler',
+        code: lambda.Code.fromInline(
+          "exports.handler = async (event) => { return { isAuthorized: event.headers['x-api-key'] === process.env.ADMIN_API_KEY }; };"
+        ),
+        environment: { ADMIN_API_KEY: commonEnv.ADMIN_API_KEY }
+      }),
+      identitySources: [apigw.IdentitySource.header('x-api-key')]
+    });
+    conv.addMethod('GET', new apigw.LambdaIntegration(getConversations), {
+      authorizer,
+      authorizationType: apigw.AuthorizationType.CUSTOM
+    });
+    convId.addMethod('GET', new apigw.LambdaIntegration(getConversationDetail), {
+      authorizer,
+      authorizationType: apigw.AuthorizationType.CUSTOM
+    });
+
+    const bucket = new s3.Bucket(this, 'AdminFrontendBucket', {
+      websiteIndexDocument: 'index.html',
+      publicReadAccess: false
+    });
+    new cloudfront.CloudFrontWebDistribution(this, 'AdminFrontendDistribution', {
+      originConfigs: [
+        {
+          s3OriginSource: { s3BucketSource: bucket },
+          behaviors: [{ isDefaultBehavior: true }]
+        }
+      ]
+    });
+
+    new CfnOutput(this, 'AdminFrontendBucketName', { value: bucket.bucketName });
+  }
+}

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "whatsapp-ai-cdk",
+  "private": true,
+  "main": "lib/WhatsAppAiStack.js",
+  "types": "lib/WhatsAppAiStack.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2",
+    "constructs": "^10",
+    "source-map-support": "^0.5",
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@aws-sdk/util-dynamodb": "^3",
+    "@aws-sdk/client-bedrock-runtime": "^3",
+    "axios": "^1"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.2",
+    "@types/node": "^18",
+    "jest": "^29",
+    "ts-jest": "^29",
+    "typescript": "^5"
+  }
+}

--- a/cdk/src/bedrock.ts
+++ b/cdk/src/bedrock.ts
@@ -1,0 +1,22 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
+
+const client = new BedrockRuntimeClient({});
+
+export async function invokeBedrock(prompt: string): Promise<string> {
+  const input = {
+    modelId: 'anthropic.claude-v2',
+    contentType: 'application/json',
+    accept: 'application/json',
+    body: JSON.stringify({ prompt, max_tokens_to_sample: 200 })
+  };
+
+  const command = new InvokeModelCommand(input);
+  const response = await client.send(command);
+  const body = new TextDecoder().decode(response.body);
+  try {
+    const parsed = JSON.parse(body);
+    return parsed.completion || body;
+  } catch {
+    return body;
+  }
+}

--- a/cdk/src/crm.ts
+++ b/cdk/src/crm.ts
@@ -1,0 +1,5 @@
+import { ConversationState } from './slots';
+
+export async function createLead(state: ConversationState): Promise<string> {
+  return `LEAD-${Date.now()}`;
+}

--- a/cdk/src/getConversationDetail.ts
+++ b/cdk/src/getConversationDetail.ts
@@ -1,0 +1,16 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+
+const client = new DynamoDBClient({});
+const TableName = process.env.TABLE_NAME || 'ConversationState';
+
+export async function main(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const sessionId = event.pathParameters?.sessionId as string;
+  const data = await client.send(new GetItemCommand({ TableName, Key: { sessionId: { S: sessionId } } }));
+  const item = data.Item ? unmarshall(data.Item) : null;
+  return {
+    statusCode: 200,
+    body: JSON.stringify(item)
+  };
+}

--- a/cdk/src/getConversations.ts
+++ b/cdk/src/getConversations.ts
@@ -1,0 +1,15 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { DynamoDBClient, ScanCommand } from '@aws-sdk/client-dynamodb';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+
+const client = new DynamoDBClient({});
+const TableName = process.env.TABLE_NAME || 'ConversationState';
+
+export async function main(): Promise<APIGatewayProxyResult> {
+  const data = await client.send(new ScanCommand({ TableName }));
+  const items = data.Items?.map(i => unmarshall(i));
+  return {
+    statusCode: 200,
+    body: JSON.stringify(items)
+  };
+}

--- a/cdk/src/handler.ts
+++ b/cdk/src/handler.ts
@@ -1,0 +1,35 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { loadState, saveState, classifyIntent, fillSlots, ConversationState } from './slots';
+import { openCase } from './sohoCrm';
+import { createLead } from './crm';
+import * as qs from 'querystring';
+
+export async function main(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const body = qs.parse(event.body || '');
+  const sessionId = body.From as string || 'unknown';
+  const text = (body.Body as string) || '';
+
+  let state = await loadState(sessionId);
+
+  if (!state.intent) {
+    state.intent = await classifyIntent(text);
+  }
+  const reply = await fillSlots(state, text);
+
+  if (state.completed) {
+    if (state.intent === 'soporte') {
+      const caseId = await openCase(state);
+      state.slots.caseId = caseId;
+    } else {
+      const leadId = await createLead(state);
+      state.slots.leadId = leadId;
+    }
+  }
+
+  await saveState(state);
+
+  return {
+    statusCode: 200,
+    body: reply
+  };
+}

--- a/cdk/src/slots.ts
+++ b/cdk/src/slots.ts
@@ -1,0 +1,59 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { defaultSlotConfig, SlotConfig } from '../config/slotConfig';
+import { invokeBedrock } from './bedrock';
+
+const tableName = process.env.TABLE_NAME || 'ConversationState';
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+export interface ConversationState {
+  sessionId: string;
+  intent?: keyof SlotConfig;
+  slots: Record<string, string>;
+  completed?: boolean;
+}
+
+export async function loadState(sessionId: string): Promise<ConversationState> {
+  const res = await ddb.send(new GetCommand({ TableName: tableName, Key: { sessionId } }));
+  return (res.Item as ConversationState) || { sessionId, slots: {} };
+}
+
+export async function saveState(state: ConversationState) {
+  await ddb.send(new PutCommand({ TableName: tableName, Item: state }));
+}
+
+function getConfig(): SlotConfig {
+  if (process.env.SLOT_CONFIG_JSON) {
+    try {
+      return JSON.parse(process.env.SLOT_CONFIG_JSON);
+    } catch {}
+  }
+  return defaultSlotConfig;
+}
+
+export async function classifyIntent(text: string): Promise<keyof SlotConfig> {
+  const prompt = `Intención del siguiente mensaje (soporte o ventas): ${text}`;
+  const result = await invokeBedrock(prompt);
+  return result.includes('venta') ? 'ventas' : 'soporte';
+}
+
+export async function fillSlots(state: ConversationState, text: string): Promise<string> {
+  const config = getConfig()[state.intent!];
+  const missing = config.required.filter(k => !state.slots[k]);
+  if (missing.length === 0) {
+    state.completed = true;
+    return 'Gracias, procesando...';
+  }
+  const prompt = `Extrae los siguientes campos del mensaje si existen: ${missing.join(', ')}. Responde JSON.`;
+  const completion = await invokeBedrock(prompt + `\nMensaje: ${text}`);
+  try {
+    const data = JSON.parse(completion);
+    for (const key of missing) {
+      if (data[key]) state.slots[key] = data[key];
+    }
+  } catch {
+    // ignore
+  }
+  const stillMissing = config.required.filter(k => !state.slots[k]);
+  return stillMissing.length ? `Necesito ${stillMissing.join(', ')}` : 'Gracias, procesando...';
+}

--- a/cdk/src/sohoCrm.ts
+++ b/cdk/src/sohoCrm.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { ConversationState } from './slots';
+
+export async function openCase(state: ConversationState): Promise<string> {
+  const url = process.env.SOHO_CRM_API_URL || '';
+  const key = process.env.SOHO_CRM_API_KEY || '';
+  const resp = await axios.post(url + '/cases', state.slots, {
+    headers: { 'x-api-key': key }
+  });
+  return resp.data.caseId as string;
+}

--- a/cdk/test/handler.test.ts
+++ b/cdk/test/handler.test.ts
@@ -1,0 +1,20 @@
+import { main as handler } from '../src/handler';
+import * as slots from '../src/slots';
+import * as soho from '../src/sohoCrm';
+import * as crm from '../src/crm';
+
+jest.mock('../src/slots');
+jest.mock('../src/sohoCrm');
+jest.mock('../src/crm');
+
+test('processes message', async () => {
+  (slots.loadState as jest.Mock).mockResolvedValue({ sessionId: '1', slots: {} });
+  (slots.classifyIntent as jest.Mock).mockResolvedValue('soporte');
+  (slots.fillSlots as jest.Mock).mockImplementation(async (state) => {
+    state.completed = true;
+    return 'ok';
+  });
+  (soho.openCase as jest.Mock).mockResolvedValue('CASE-1');
+  const res = await handler({ body: 'Body=hola&From=123' } as any);
+  expect(res.statusCode).toBe(200);
+});

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["es2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "lib/**/*.ts", "test/**/*.ts", "config/**/*.ts"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  projects: ['<rootDir>/cdk']
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "whatsapp-ai-cdk",
+  "private": true,
+  "workspaces": [
+    "cdk",
+    "admin-frontend"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.149",
+    "@types/jest": "^29.5.2",
+    "@types/node": "^18",
+    "jest": "^29",
+    "ts-jest": "^29",
+    "typescript": "^5"
+  },
+  "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3",
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@aws-sdk/util-dynamodb": "^3",
+    "axios": "^1"
+  }
+}


### PR DESCRIPTION
## Summary
- implement CDK stack and Lambda sources
- add slot configuration and Bedrock helpers
- create minimal admin React front-end
- provide unit test for the handler

## Testing
- `npm --workspace=cdk run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848517465c083328b8c2d8357cc00f1